### PR TITLE
Add support for configurable opening, closing quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,13 @@
  * @typedef {import('nlcst').Punctuation} Punctuation
  * @typedef {import('nlcst').SentenceContent} SentenceContent
  *
+ * @typedef QuoteCharacterMap
+ *   Quote characters.
+ * @property {string} double
+ *   Character to use for double quotes.
+ * @property {string} single
+ *   Character to use for single quotes.
+ *
  * @typedef Options
  *   Configuration.
  * @property {boolean} [quotes=true]
@@ -13,9 +20,9 @@
  *
  *   Converts straight double and single quotes to smart double or single
  *   quotes.
- * @property {{ '"': string; "'": string }} [openingQuotes]
+ * @property {QuoteCharacterMap} [openingQuotes]
  *   Characters to use for opening double and single quotes.
- * @property {{ '"': string; "'": string }} [closingQuotes]
+ * @property {QuoteCharacterMap} [closingQuotes]
  *   Characters to use for closing double and single quotes.
  * @property {boolean} [ellipses=true]
  *   Create smart ellipses.
@@ -61,10 +68,12 @@ const defaultOpeningQuotes = {'"': '“', "'": '‘'}
  * @param {Options} options
  */
 function createEducators(options) {
-  const {
-    closingQuotes = defaultClosingQuotes,
-    openingQuotes = defaultOpeningQuotes
-  } = options
+  const closingQuotes = options.closingQuotes
+    ? {'"': options.closingQuotes.double, "'": options.closingQuotes.single}
+    : defaultClosingQuotes
+  const openingQuotes = options.openingQuotes
+    ? {'"': options.openingQuotes.double, "'": options.openingQuotes.single}
+    : defaultOpeningQuotes
 
   const educators = {
     dashes: {

--- a/index.js
+++ b/index.js
@@ -120,9 +120,9 @@ function createEducators(options) {
        */
       true(node) {
         if (node.value === '``') {
-          node.value = '“'
+          node.value = openingQuotes['"']
         } else if (node.value === "''") {
-          node.value = '”'
+          node.value = closingQuotes['"']
         }
       },
       /**
@@ -134,9 +134,9 @@ function createEducators(options) {
         educators.backticks.true(node, index, parent)
 
         if (node.value === '`') {
-          node.value = '‘'
+          node.value = openingQuotes["'"]
         } else if (node.value === "'") {
-          node.value = '’'
+          node.value = closingQuotes["'"]
         }
       }
     },

--- a/index.js
+++ b/index.js
@@ -13,6 +13,10 @@
  *
  *   Converts straight double and single quotes to smart double or single
  *   quotes.
+ * @property {{ '"': string; "'": string }} [openingQuotes]
+ *   Characters to use for opening double and single quotes.
+ * @property {{ '"': string; "'": string }} [closingQuotes]
+ *   Characters to use for closing double and single quotes.
  * @property {boolean} [ellipses=true]
  *   Create smart ellipses.
  *
@@ -50,209 +54,218 @@
 import {visit} from 'unist-util-visit'
 import {toString} from 'nlcst-to-string'
 
-const closingQuotes = {'"': '”', "'": '’'}
-const openingQuotes = {'"': '“', "'": '‘'}
+const defaultClosingQuotes = {'"': '”', "'": '’'}
+const defaultOpeningQuotes = {'"': '“', "'": '‘'}
 
-const educators = {
-  dashes: {
-    /**
-     * Transform two dahes into an em-dash.
-     *
-     * @type {Method}
-     */
-    true(node) {
-      if (node.value === '--') {
-        node.value = '—'
+function createEducators(/** @type {Options} */ options = {}) {
+  const {
+    closingQuotes = defaultClosingQuotes,
+    openingQuotes = defaultOpeningQuotes
+  } = options
+
+  const educators = {
+    dashes: {
+      /**
+       * Transform two dahes into an em-dash.
+       *
+       * @type {Method}
+       */
+      true(node) {
+        if (node.value === '--') {
+          node.value = '—'
+        }
+      },
+      /**
+       * Transform three dahes into an em-dash, and two into an en-dash.
+       *
+       * @type {Method}
+       */
+      oldschool(node) {
+        if (node.value === '---') {
+          node.value = '—'
+        } else if (node.value === '--') {
+          node.value = '–'
+        }
+      },
+      /**
+       * Transform three dahes into an en-dash, and two into an em-dash.
+       *
+       * @type {Method}
+       */
+      inverted(node) {
+        if (node.value === '---') {
+          node.value = '–'
+        } else if (node.value === '--') {
+          node.value = '—'
+        }
       }
     },
-    /**
-     * Transform three dahes into an em-dash, and two into an en-dash.
-     *
-     * @type {Method}
-     */
-    oldschool(node) {
-      if (node.value === '---') {
-        node.value = '—'
-      } else if (node.value === '--') {
-        node.value = '–'
+    backticks: {
+      /**
+       * Transform double backticks and single quotes into smart quotes.
+       *
+       * @type {Method}
+       */
+      true(node) {
+        if (node.value === '``') {
+          node.value = '“'
+        } else if (node.value === "''") {
+          node.value = '”'
+        }
+      },
+      /**
+       * Transform single and double backticks and single quotes into smart quotes.
+       *
+       * @type {Method}
+       */
+      all(node, index, parent) {
+        educators.backticks.true(node, index, parent)
+
+        if (node.value === '`') {
+          node.value = '‘'
+        } else if (node.value === "'") {
+          node.value = '’'
+        }
       }
     },
-    /**
-     * Transform three dahes into an en-dash, and two into an em-dash.
-     *
-     * @type {Method}
-     */
-    inverted(node) {
-      if (node.value === '---') {
-        node.value = '–'
-      } else if (node.value === '--') {
-        node.value = '—'
-      }
-    }
-  },
-  backticks: {
-    /**
-     * Transform double backticks and single quotes into smart quotes.
-     *
-     * @type {Method}
-     */
-    true(node) {
-      if (node.value === '``') {
-        node.value = '“'
-      } else if (node.value === "''") {
-        node.value = '”'
-      }
-    },
-    /**
-     * Transform single and double backticks and single quotes into smart quotes.
-     *
-     * @type {Method}
-     */
-    all(node, index, parent) {
-      educators.backticks.true(node, index, parent)
+    ellipses: {
+      /**
+       * Transform multiple dots into unicode ellipses.
+       *
+       * @type {Method}
+       */
+      true(node, index, parent) {
+        const value = node.value
+        const siblings = parent.children
 
-      if (node.value === '`') {
-        node.value = '‘'
-      } else if (node.value === "'") {
-        node.value = '’'
-      }
-    }
-  },
-  ellipses: {
-    /**
-     * Transform multiple dots into unicode ellipses.
-     *
-     * @type {Method}
-     */
-    true(node, index, parent) {
-      const value = node.value
-      const siblings = parent.children
+        // Simple node with three dots and without white-space.
+        if (/^\.{3,}$/.test(node.value)) {
+          node.value = '…'
+          return
+        }
 
-      // Simple node with three dots and without white-space.
-      if (/^\.{3,}$/.test(node.value)) {
-        node.value = '…'
-        return
-      }
+        if (!/^\.+$/.test(value)) {
+          return
+        }
 
-      if (!/^\.+$/.test(value)) {
-        return
-      }
+        // Search for dot-nodes with white-space between.
+        /** @type {SentenceContent[]} */
+        const nodes = []
+        let position = index
+        let count = 1
 
-      // Search for dot-nodes with white-space between.
-      /** @type {SentenceContent[]} */
-      const nodes = []
-      let position = index
-      let count = 1
+        // It’s possible that the node is merged with an adjacent word-node.  In that
+        // code, we cannot transform it because there’s no reference to the
+        // grandparent.
+        while (--position > 0) {
+          let sibling = siblings[position]
 
-      // It’s possible that the node is merged with an adjacent word-node.  In that
-      // code, we cannot transform it because there’s no reference to the
-      // grandparent.
-      while (--position > 0) {
-        let sibling = siblings[position]
+          if (sibling.type !== 'WhiteSpaceNode') {
+            break
+          }
 
-        if (sibling.type !== 'WhiteSpaceNode') {
+          const queue = sibling
+          sibling = siblings[--position]
+
+          if (
+            sibling &&
+            (sibling.type === 'PunctuationNode' ||
+              sibling.type === 'SymbolNode') &&
+            /^\.+$/.test(sibling.value)
+          ) {
+            nodes.push(queue, sibling)
+
+            count++
+
+            continue
+          }
+
           break
         }
 
-        const queue = sibling
-        sibling = siblings[--position]
-
-        if (
-          sibling &&
-          (sibling.type === 'PunctuationNode' ||
-            sibling.type === 'SymbolNode') &&
-          /^\.+$/.test(sibling.value)
-        ) {
-          nodes.push(queue, sibling)
-
-          count++
-
-          continue
+        if (count < 3) {
+          return
         }
 
-        break
+        siblings.splice(index - nodes.length, nodes.length)
+
+        node.value = '…'
       }
+    },
+    quotes: {
+      /**
+       * Transform straight single- and double quotes into smart quotes.
+       *
+       * @type {Method}
+       */
+      // eslint-disable-next-line complexity
+      true(node, index, parent) {
+        const siblings = parent.children
+        const value = node.value
 
-      if (count < 3) {
-        return
-      }
+        if (value !== '"' && value !== "'") {
+          return
+        }
 
-      siblings.splice(index - nodes.length, nodes.length)
+        const previous = siblings[index - 1]
+        const next = siblings[index + 1]
+        const nextNext = siblings[index + 2]
+        const nextValue = next && toString(next)
 
-      node.value = '…'
-    }
-  },
-  quotes: {
-    /**
-     * Transform straight single- and double quotes into smart quotes.
-     *
-     * @type {Method}
-     */
-    // eslint-disable-next-line complexity
-    true(node, index, parent) {
-      const siblings = parent.children
-      const value = node.value
-
-      if (value !== '"' && value !== "'") {
-        return
-      }
-
-      const previous = siblings[index - 1]
-      const next = siblings[index + 1]
-      const nextNext = siblings[index + 2]
-      const nextValue = next && toString(next)
-
-      if (
-        next &&
-        nextNext &&
-        (next.type === 'PunctuationNode' || next.type === 'SymbolNode') &&
-        nextNext.type !== 'WordNode'
-      ) {
-        // Special case if the very first character is a quote followed by
-        // punctuation at a non-word-break. Close the quotes by brute force.
-        node.value = closingQuotes[value]
-      } else if (
-        nextNext &&
-        (nextValue === '"' || nextValue === "'") &&
-        nextNext.type === 'WordNode'
-      ) {
-        // Special case for double sets of quotes:
-        // `He said, "'Quoted' words in a larger quote."`
-        node.value = openingQuotes[value]
-        // @ts-expect-error: it’s a literal.
-        next.value = openingQuotes[nextValue]
-      } else if (next && /^\d\ds$/.test(nextValue)) {
-        // Special case for decade abbreviations: `the '80s`
-        node.value = closingQuotes[value]
-      } else if (
-        previous &&
-        next &&
-        (previous.type === 'WhiteSpaceNode' ||
-          previous.type === 'PunctuationNode' ||
-          previous.type === 'SymbolNode') &&
-        next.type === 'WordNode'
-      ) {
-        // Get most opening single quotes.
-        node.value = openingQuotes[value]
-      } else if (
-        previous &&
-        previous.type !== 'WhiteSpaceNode' &&
-        previous.type !== 'SymbolNode' &&
-        previous.type !== 'PunctuationNode'
-      ) {
-        // Closing quotes.
-        node.value = closingQuotes[value]
-      } else if (
-        !next ||
-        next.type === 'WhiteSpaceNode' ||
-        (value === "'" && nextValue === 's')
-      ) {
-        node.value = closingQuotes[value]
-      } else {
-        node.value = openingQuotes[value]
+        if (
+          next &&
+          nextNext &&
+          (next.type === 'PunctuationNode' || next.type === 'SymbolNode') &&
+          nextNext.type !== 'WordNode'
+        ) {
+          // Special case if the very first character is a quote followed by
+          // punctuation at a non-word-break. Close the quotes by brute force.
+          node.value = closingQuotes[value]
+        } else if (
+          nextNext &&
+          (nextValue === '"' || nextValue === "'") &&
+          nextNext.type === 'WordNode'
+        ) {
+          // Special case for double sets of quotes:
+          // `He said, "'Quoted' words in a larger quote."`
+          node.value = openingQuotes[value]
+          // @ts-expect-error: it’s a literal.
+          next.value = openingQuotes[nextValue]
+        } else if (next && /^\d\ds$/.test(nextValue)) {
+          // Special case for decade abbreviations: `the '80s`
+          node.value = closingQuotes[value]
+        } else if (
+          previous &&
+          next &&
+          (previous.type === 'WhiteSpaceNode' ||
+            previous.type === 'PunctuationNode' ||
+            previous.type === 'SymbolNode') &&
+          next.type === 'WordNode'
+        ) {
+          // Get most opening single quotes.
+          node.value = openingQuotes[value]
+        } else if (
+          previous &&
+          previous.type !== 'WhiteSpaceNode' &&
+          previous.type !== 'SymbolNode' &&
+          previous.type !== 'PunctuationNode'
+        ) {
+          // Closing quotes.
+          node.value = closingQuotes[value]
+        } else if (
+          !next ||
+          next.type === 'WhiteSpaceNode' ||
+          (value === "'" && nextValue === 's')
+        ) {
+          node.value = closingQuotes[value]
+        } else {
+          node.value = openingQuotes[value]
+        }
       }
     }
   }
+
+  return educators
 }
 
 /**
@@ -352,6 +365,8 @@ export default function retextSmartypants(options = {}) {
   } else {
     dashes = true
   }
+
+  const educators = createEducators(options)
 
   if (quotes !== false) {
     methods.push(educators.quotes.true)

--- a/index.js
+++ b/index.js
@@ -57,7 +57,10 @@ import {toString} from 'nlcst-to-string'
 const defaultClosingQuotes = {'"': '”', "'": '’'}
 const defaultOpeningQuotes = {'"': '“', "'": '‘'}
 
-function createEducators(/** @type {Options} */ options = {}) {
+/**
+ * @param {Options} options
+ */
+function createEducators(options) {
   const {
     closingQuotes = defaultClosingQuotes,
     openingQuotes = defaultOpeningQuotes

--- a/index.js
+++ b/index.js
@@ -120,9 +120,9 @@ function createEducators(options) {
        */
       true(node) {
         if (node.value === '``') {
-          node.value = openingQuotes['"']
+          node.value = '“'
         } else if (node.value === "''") {
-          node.value = closingQuotes['"']
+          node.value = '”'
         }
       },
       /**
@@ -134,9 +134,9 @@ function createEducators(options) {
         educators.backticks.true(node, index, parent)
 
         if (node.value === '`') {
-          node.value = openingQuotes["'"]
+          node.value = '‘'
         } else if (node.value === "'") {
-          node.value = closingQuotes["'"]
+          node.value = '’'
         }
       }
     },

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,14 @@ Create smart quotes (`boolean`, default: `true`).
 
 Converts straight double and single quotes to smart double or single quotes.
 
+###### `options.openingQuotes`
+
+Which characters to use for opening quotes `{ double: '”', single: '’' }`.
+
+###### `options.closingQuotes`
+
+Which characters to use for closing quotes `{ double: '”', single: '‘' }`.
+
 ###### `options.ellipses`
 
 Create smart ellipses (`boolean`, default: `true`).

--- a/readme.md
+++ b/readme.md
@@ -60,11 +60,11 @@ Converts straight double and single quotes to smart double or single quotes.
 
 ###### `options.openingQuotes`
 
-Which characters to use for opening quotes `{ double: '”', single: '’' }`.
+Which characters to use for opening quotes `{double: '“', single: '‘'}`.
 
 ###### `options.closingQuotes`
 
-Which characters to use for closing quotes `{ double: '”', single: '‘' }`.
+Which characters to use for closing quotes `{double: '”', single: '’'}`.
 
 ###### `options.ellipses`
 

--- a/test.js
+++ b/test.js
@@ -420,6 +420,42 @@ test('Backticks', (t) => {
       }
     )
 
+    st.test(
+      'should replace two backticks with an opening double quote from options',
+      (sst) => {
+        sst.equal(
+          retext()
+            .use(retextSmartypants, {
+              quotes: false,
+              openingQuotes: {double: '«', single: '‹'}
+            })
+            .processSync('``Alfred bertrand.')
+            .toString(),
+          '«Alfred bertrand.'
+        )
+
+        sst.end()
+      }
+    )
+
+    st.test(
+      'should replace two single quotes with a closing double quote from options',
+      (sst) => {
+        sst.equal(
+          retext()
+            .use(retextSmartypants, {
+              quotes: false,
+              closingQuotes: {double: '»', single: '›'}
+            })
+            .processSync("Alfred'' bertrand.")
+            .toString(),
+          'Alfred» bertrand.'
+        )
+
+        sst.end()
+      }
+    )
+
     st.test('should NOT replace a single backtick', (sst) => {
       sst.equal(
         processor.processSync('`Alfred bertrand.').toString(),
@@ -486,6 +522,82 @@ test('Backticks', (t) => {
 
       sst.end()
     })
+
+    st.test(
+      'should replace two backticks with an opening double quote from options',
+      (sst) => {
+        sst.equal(
+          retext()
+            .use(retextSmartypants, {
+              backticks: 'all',
+              quotes: false,
+              openingQuotes: {double: '«', single: '‹'}
+            })
+            .processSync('``Alfred bertrand.')
+            .toString(),
+          '«Alfred bertrand.'
+        )
+
+        sst.end()
+      }
+    )
+
+    st.test(
+      'should replace two single quotes with a closing double quote from options',
+      (sst) => {
+        sst.equal(
+          retext()
+            .use(retextSmartypants, {
+              backticks: 'all',
+              quotes: false,
+              closingQuotes: {double: '»', single: '›'}
+            })
+            .processSync("Alfred'' bertrand.")
+            .toString(),
+          'Alfred» bertrand.'
+        )
+
+        sst.end()
+      }
+    )
+
+    st.test(
+      'should replace a single backtick with character from options',
+      (sst) => {
+        sst.equal(
+          retext()
+            .use(retextSmartypants, {
+              backticks: 'all',
+              quotes: false,
+              openingQuotes: {double: '«', single: '‹'}
+            })
+            .processSync('`Alfred bertrand.')
+            .toString(),
+          '‹Alfred bertrand.'
+        )
+
+        sst.end()
+      }
+    )
+
+    st.test(
+      'should replace a single quote from options with character from options',
+      (sst) => {
+        sst.equal(
+          retext()
+            .use(retextSmartypants, {
+              backticks: 'all',
+              quotes: false,
+              closingQuotes: {double: '»', single: '›'}
+            })
+            .processSync("Alfred' bertrand.")
+            .toString(),
+          'Alfred› bertrand.'
+        )
+
+        sst.end()
+      }
+    )
 
     st.end()
   })

--- a/test.js
+++ b/test.js
@@ -267,6 +267,21 @@ test('Curly quotes', (t) => {
     }
   )
 
+  t.test('should use quotes from options', (st) => {
+    st.equal(
+      retext()
+        .use(retextSmartypants, {
+          openingQuotes: {'"': '«', "'": '‹'},
+          closingQuotes: {'"': '»', "'": '›'}
+        })
+        .processSync('Alfred "bertrand" \'cees\'.')
+        .toString(),
+      'Alfred «bertrand» ‹cees›.'
+    )
+
+    st.end()
+  })
+
   t.end()
 })
 

--- a/test.js
+++ b/test.js
@@ -271,8 +271,8 @@ test('Curly quotes', (t) => {
     st.equal(
       retext()
         .use(retextSmartypants, {
-          openingQuotes: {'"': '«', "'": '‹'},
-          closingQuotes: {'"': '»', "'": '›'}
+          openingQuotes: {double: '«', single: '‹'},
+          closingQuotes: {double: '»', single: '›'}
         })
         .processSync('Alfred "bertrand" \'cees\'.')
         .toString(),

--- a/test.js
+++ b/test.js
@@ -420,42 +420,6 @@ test('Backticks', (t) => {
       }
     )
 
-    st.test(
-      'should replace two backticks with an opening double quote from options',
-      (sst) => {
-        sst.equal(
-          retext()
-            .use(retextSmartypants, {
-              quotes: false,
-              openingQuotes: {double: '«', single: '‹'}
-            })
-            .processSync('``Alfred bertrand.')
-            .toString(),
-          '«Alfred bertrand.'
-        )
-
-        sst.end()
-      }
-    )
-
-    st.test(
-      'should replace two single quotes with a closing double quote from options',
-      (sst) => {
-        sst.equal(
-          retext()
-            .use(retextSmartypants, {
-              quotes: false,
-              closingQuotes: {double: '»', single: '›'}
-            })
-            .processSync("Alfred'' bertrand.")
-            .toString(),
-          'Alfred» bertrand.'
-        )
-
-        sst.end()
-      }
-    )
-
     st.test('should NOT replace a single backtick', (sst) => {
       sst.equal(
         processor.processSync('`Alfred bertrand.').toString(),
@@ -522,82 +486,6 @@ test('Backticks', (t) => {
 
       sst.end()
     })
-
-    st.test(
-      'should replace two backticks with an opening double quote from options',
-      (sst) => {
-        sst.equal(
-          retext()
-            .use(retextSmartypants, {
-              backticks: 'all',
-              quotes: false,
-              openingQuotes: {double: '«', single: '‹'}
-            })
-            .processSync('``Alfred bertrand.')
-            .toString(),
-          '«Alfred bertrand.'
-        )
-
-        sst.end()
-      }
-    )
-
-    st.test(
-      'should replace two single quotes with a closing double quote from options',
-      (sst) => {
-        sst.equal(
-          retext()
-            .use(retextSmartypants, {
-              backticks: 'all',
-              quotes: false,
-              closingQuotes: {double: '»', single: '›'}
-            })
-            .processSync("Alfred'' bertrand.")
-            .toString(),
-          'Alfred» bertrand.'
-        )
-
-        sst.end()
-      }
-    )
-
-    st.test(
-      'should replace a single backtick with character from options',
-      (sst) => {
-        sst.equal(
-          retext()
-            .use(retextSmartypants, {
-              backticks: 'all',
-              quotes: false,
-              openingQuotes: {double: '«', single: '‹'}
-            })
-            .processSync('`Alfred bertrand.')
-            .toString(),
-          '‹Alfred bertrand.'
-        )
-
-        sst.end()
-      }
-    )
-
-    st.test(
-      'should replace a single quote from options with character from options',
-      (sst) => {
-        sst.equal(
-          retext()
-            .use(retextSmartypants, {
-              backticks: 'all',
-              quotes: false,
-              closingQuotes: {double: '»', single: '›'}
-            })
-            .processSync("Alfred' bertrand.")
-            .toString(),
-          'Alfred› bertrand.'
-        )
-
-        sst.end()
-      }
-    )
 
     st.end()
   })


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/retextjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/retextjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/retextjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aretextjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

languages other than english might have other conventions for which characters to display for opening and closing quotes. this pr adds two options to make opening and closing quotes configurable.

<!--do not edit: pr-->
