### PR TITLE
allow escaping quotes with backslash

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,6 +224,16 @@ function createEducators(options) {
         const nextNext = siblings[index + 2]
         const nextValue = next && toString(next)
 
+        // If preceded by a backslash, don't substitute
+        if (
+          previous &&
+          previous.type === 'PunctuationNode' &&
+          previous.value === '\\'
+        ) {
+          parent.children.splice(index - 1, 1)
+          return
+        }
+
         if (
           next &&
           nextNext &&

--- a/test.js
+++ b/test.js
@@ -267,6 +267,30 @@ test('Curly quotes', (t) => {
     }
   )
 
+  t.test(
+    'should never curl double quotes when escaped with a backslash',
+    (st) => {
+      st.equal(
+        processor.processSync('\\"Hello, world.\\"').toString(),
+        '"Hello, world."'
+      )
+
+      st.end()
+    }
+  )
+
+  t.test(
+    'should never curl single quotes when escaped with a backslash',
+    (st) => {
+      st.equal(
+        processor.processSync("\\'Hello, world.\\'").toString(),
+        "'Hello, world.'"
+      )
+
+      st.end()
+    }
+  )
+
   t.test('should use quotes from options', (st) => {
     st.equal(
       retext()


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/retextjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/retextjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/retextjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aretextjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This PR allows users to prevent quote curling by escaping the quotes with a backslash, in line with [this SmartyPants feature](https://daringfireball.net/projects/smartypants/#:~:text=SmartyPants%20now%20accepts%20the%20following%20backslash%20escapes%2C%20to%20force%20non%2Dsmart%20punctuation)

This is an incomplete implementation of the feature described in the SmartyPants docs:
❌ `\\` -> `\`
✅ `\"` -> `"`
✅ `\'` -> `'`
❌ `\.` -> `.`
❌ `\-` -> `-`
❌ `` \` `` -> `` ` ``

As is, this is probably sufficient for most use cases, but it doesn't handle some edge cases:
✅ `\"Hello, world\"` -> `"Hello, world"`
❌ `\\\"Hello, world\\\"` -> `\"Hello, world\"`

If you don't want to merge a half-baked feature, I'd be happy to add some better handling for these cases

<!--do not edit: pr-->
