### PR TITLE
Add expanded ellipses options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -243,7 +243,7 @@ function ellipsesUnspaced(_, node) {
 }
 
 /**
- * Transform multiple dots into unicode ellipses (only for those with spaces).
+ * Transform multiple dots with spaces into unicode ellipses.
  *
  * @type {Method}
  */

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@
  *   dash;
  *   when `'inverted'`, turns three dashes into an en dash and two into an em
  *   dash.
- * @property {'unspaced' | 'spaced' | boolean | null | undefined} [ellipses=true]
+ * @property {'spaced' | 'unspaced' | boolean | null | undefined} [ellipses=true]
  *   Transform triple dots (default: `true`), with or without spaces between.
  *   when `true`, turns triple dots into ellipses (with or without spaces between);
  *   when `'unspaced'`, turns triple dots into ellipses (only for those without spaces);

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,10 +39,10 @@
  *   when `'inverted'`, turns three dashes into an en dash and two into an em
  *   dash.
  * @property {'spaced' | 'unspaced' | boolean | null | undefined} [ellipses=true]
- *   Transform triple dots (default: `true`), with or without spaces between.
- *   when `true`, turns triple dots into ellipses (with or without spaces between);
- *   when `'unspaced'`, turns triple dots into ellipses (only for those without spaces);
- *   when `'spaced'`, turns triple dots into ellipses (only for those with spaces).
+ *   Transform triple dots (default: `true`).
+ *   when `'spaced'`, turns triple dots with spaces into ellipses;
+ *   when `'unspaced'`, turns triple dots without spaces into ellipses;
+ *   when `true`, turns triple dots with or without spaces into ellipses.
  * @property {QuoteCharacterMap | null | undefined} [openingQuotes]
  *   Opening quotes to use (default: `{double: '“', single: '‘'}`).
  * @property {boolean | null | undefined} [quotes=true]

--- a/lib/index.js
+++ b/lib/index.js
@@ -98,7 +98,7 @@ export default function retextSmartypants(options) {
     methods.push(ellipsesSpaced)
   } else if (settings.ellipses === 'unspaced') {
     methods.push(ellipsesUnspaced)
-  } else if (settings.ellipses) {
+  } else if (settings.ellipses !== false) {
     methods.push(ellipsesDefault)
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -231,7 +231,7 @@ function ellipsesDefault(_, node, index, parent) {
 }
 
 /**
- * Transform multiple dots into unicode ellipses (only for those without spaces).
+ * Transform multiple dots without spaces into unicode ellipses.
  *
  * @type {Method}
  */

--- a/lib/index.js
+++ b/lib/index.js
@@ -94,11 +94,11 @@ export default function retextSmartypants(options) {
     methods.push(quotesDefault)
   }
 
-  if (settings.ellipses === 'unspaced') {
-    methods.push(ellipsesUnspaced)
-  } else if (settings.ellipses === 'spaced') {
+  if (settings.ellipses === 'spaced') {
     methods.push(ellipsesSpaced)
-  } else if (settings.ellipses !== false) {
+  } else if (settings.ellipses === 'unspaced') {
+    methods.push(ellipsesUnspaced)
+  } else if (settings.ellipses) {
     methods.push(ellipsesDefault)
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -226,20 +226,8 @@ function dashesOldschool(_, node) {
  * @type {Method}
  */
 function ellipsesDefault(_, node, index, parent) {
-  ellipsesUnspaced(_, node, index, parent)
   ellipsesSpaced(_, node, index, parent)
-}
-
-/**
- * Transform multiple dots without spaces into unicode ellipses.
- *
- * @type {Method}
- */
-function ellipsesUnspaced(_, node) {
-  // Simple node with three dots and without whitespace.
-  if (/^\.{3,}$/.test(node.value)) {
-    node.value = '…'
-  }
+  ellipsesUnspaced(_, node, index, parent)
 }
 
 /**
@@ -296,6 +284,18 @@ function ellipsesSpaced(_, node, index, parent) {
   siblings.splice(index - nodes.length, nodes.length)
 
   node.value = '…'
+}
+
+/**
+ * Transform multiple dots without spaces into unicode ellipses.
+ *
+ * @type {Method}
+ */
+function ellipsesUnspaced(_, node) {
+  // Simple node with three dots and without whitespace.
+  if (/^\.{3,}$/.test(node.value)) {
+    node.value = '…'
+  }
 }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,8 +38,11 @@
  *   dash;
  *   when `'inverted'`, turns three dashes into an en dash and two into an em
  *   dash.
- * @property {boolean | null | undefined} [ellipses=true]
+ * @property {'unspaced' | 'spaced' | boolean | null | undefined} [ellipses=true]
  *   Transform triple dots (default: `true`), with or without spaces between.
+ *   when `true`, turns triple dots into ellipses (with or without spaces between);
+ *   when `'unspaced'`, turns triple dots into ellipses (only for those without spaces);
+ *   when `'spaced'`, turns triple dots into ellipses (only for those with spaces).
  * @property {QuoteCharacterMap | null | undefined} [openingQuotes]
  *   Opening quotes to use (default: `{double: '“', single: '‘'}`).
  * @property {boolean | null | undefined} [quotes=true]
@@ -91,7 +94,11 @@ export default function retextSmartypants(options) {
     methods.push(quotesDefault)
   }
 
-  if (settings.ellipses !== false) {
+  if (settings.ellipses === 'unspaced') {
+    methods.push(ellipsesUnspaced)
+  } else if (settings.ellipses === 'spaced') {
+    methods.push(ellipsesSpaced)
+  } else if (settings.ellipses !== false) {
     methods.push(ellipsesDefault)
   }
 
@@ -219,14 +226,30 @@ function dashesOldschool(_, node) {
  * @type {Method}
  */
 function ellipsesDefault(_, node, index, parent) {
-  const value = node.value
-  const siblings = parent.children
+  ellipsesUnspaced(_, node, index, parent)
+  ellipsesSpaced(_, node, index, parent)
+}
 
+/**
+ * Transform multiple dots into unicode ellipses (only for those without spaces).
+ *
+ * @type {Method}
+ */
+function ellipsesUnspaced(_, node) {
   // Simple node with three dots and without whitespace.
   if (/^\.{3,}$/.test(node.value)) {
     node.value = '…'
-    return
   }
+}
+
+/**
+ * Transform multiple dots into unicode ellipses (only for those with spaces).
+ *
+ * @type {Method}
+ */
+function ellipsesSpaced(_, node, index, parent) {
+  const value = node.value
+  const siblings = parent.children
 
   if (!/^\.+$/.test(value)) {
     return

--- a/readme.md
+++ b/readme.md
@@ -115,19 +115,22 @@ Configuration (TypeScript type).
     `{double: '”', single: '’'}`)
     — closing quotes to use
 *   `dashes` (`'inverted'` or `'oldschool'` or `boolean`, default: `true`)
-    transform dashes;
+    — transform dashes;
     when `true`, turns two dashes into an em dash character;
     when `'oldschool'`, turns three dashes into an em dash and two into an en
     dash;
     when `'inverted'`, turns three dashes into an en dash and two into an em
     dash
-*   `ellipses` (`boolean`, default: `true`)
-    — transform triple dots, with or without spaces between
+*   `ellipses` (`'spaced'` or `'unspaced'` or `boolean`, default: `true`)
+    — transform triple dots;
+    when `'spaced'`, turns triple dots with spaces into ellipses;
+    when `'unspaced'`, turns triple dots without spaces into ellipses;
+    when `true`, turns triple dots with or without spaces into ellipses
 *   `openingQuotes` ([`QuoteCharacterMap`][api-quote-character-map], default:
     `{double: '“', single: '‘'}`)
     — opening quotes to use
 *   `quotes` (`boolean`, default: `true`)
-    — Transform straight quotes into smart quotes
+    — transform straight quotes into smart quotes
 
 ### `QuoteCharacterMap`
 

--- a/test.js
+++ b/test.js
@@ -554,3 +554,156 @@ test('Ellipses', async function (t) {
     }
   )
 })
+
+test('Ellipses (unspaced)', async function (t) {
+  const processor = retext().use(retextSmartypants, {ellipses: 'unspaced'})
+
+  await t.test('should replace three full stops', async function () {
+    assert.equal(
+      processor.processSync('Alfred... Bertrand.').toString(),
+      'Alfred\u2026 Bertrand.'
+    )
+  })
+
+  await t.test('should replace three initial full stops', async function () {
+    assert.equal(
+      processor.processSync('...Alfred Bertrand.').toString(),
+      '\u2026Alfred Bertrand.'
+    )
+  })
+
+  await t.test('should replace three final full stops', async function () {
+    assert.equal(
+      processor.processSync('Alfred Bertrand...').toString(),
+      'Alfred Bertrand\u2026'
+    )
+  })
+
+  await t.test('should replace three padded full stops', async function () {
+    assert.equal(
+      processor.processSync('Alfred ... Bertrand.').toString(),
+      'Alfred \u2026 Bertrand.'
+    )
+  })
+
+  await t.test(
+    'should replace three padded initial full stops',
+    async function () {
+      assert.equal(
+        processor.processSync('... Alfred Bertrand.').toString(),
+        '\u2026 Alfred Bertrand.'
+      )
+    }
+  )
+
+  await t.test(
+    'should replace three padded final full stops',
+    async function () {
+      assert.equal(
+        processor.processSync('Alfred Bertrand ...').toString(),
+        'Alfred Bertrand \u2026'
+      )
+    }
+  )
+
+  await t.test('should replace more than three full stops', async function () {
+    assert.equal(
+      processor.processSync('Alfred..... Bertrand.').toString(),
+      'Alfred\u2026 Bertrand.'
+    )
+
+    assert.equal(
+      processor.processSync('Alfred bertrand....').toString(),
+      'Alfred bertrand\u2026'
+    )
+
+    assert.equal(
+      processor.processSync('......Alfred bertrand.').toString(),
+      '\u2026Alfred bertrand.'
+    )
+  })
+
+  await t.test(
+    'should NOT replace less than three full stops',
+    async function () {
+      assert.equal(
+        processor.processSync('Alfred.. Bertrand.').toString(),
+        'Alfred.. Bertrand.'
+      )
+
+      assert.equal(
+        processor.processSync('Alfred bertrand. .').toString(),
+        'Alfred bertrand. .'
+      )
+
+      assert.equal(
+        processor.processSync('.Alfred bertrand.').toString(),
+        '.Alfred bertrand.'
+      )
+    }
+  )
+})
+
+test('Ellipses (spaced)', async function (t) {
+  const processor = retext().use(retextSmartypants, {ellipses: 'spaced'})
+
+  await t.test(
+    'should replace three padded full stops with spaces',
+    async function () {
+      assert.equal(
+        processor.processSync('Alfred . . . Bertrand.').toString(),
+        'Alfred \u2026 Bertrand.'
+      )
+    }
+  )
+
+  await t.test(
+    'should replace three padded initial full stops with spaces',
+    async function () {
+      assert.equal(
+        processor.processSync('. . . Alfred Bertrand.').toString(),
+        '\u2026 Alfred Bertrand.'
+      )
+    }
+  )
+
+  await t.test(
+    'should replace three padded final full stops with spaces',
+    async function () {
+      assert.equal(
+        processor.processSync('Alfred Bertrand . . .').toString(),
+        'Alfred Bertrand \u2026'
+      )
+    }
+  )
+
+  await t.test(
+    'should replace three full stops with spaces',
+    async function () {
+      assert.equal(
+        processor.processSync('Alfred. . . Bertrand.').toString(),
+        'Alfred\u2026 Bertrand.'
+      )
+    }
+  )
+
+  await t.test(
+    'should replace three initial full stops with spaces',
+    async function () {
+      assert.equal(
+        processor.processSync('. . .Alfred Bertrand.').toString(),
+        '\u2026Alfred Bertrand.'
+      )
+    }
+  )
+
+  await t.test(
+    'should replace three final full stops with spaces',
+    async function () {
+      assert.equal(
+        processor.processSync('Alfred Bertrand. . .').toString(),
+        'Alfred Bertrand\u2026'
+      )
+    }
+  )
+})


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/retextjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/retextjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/retextjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aretextjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Re: #9 discussion, this PR adds `'unspaced'` and `'spaced'` options to ellipses config:

- when `true`, turns triple dots into ellipses (with or without spaces between);
- when `'unspaced'`, turns triple dots into ellipses (only for those without spaces);
- when `'spaced'`, turns triple dots into ellipses (only for those with spaces).

<!--do not edit: pr-->
