### PR TITLE
Fix closing quote after parentheses and brackets

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -360,7 +360,7 @@ function quotesDefault(state, node, index, parent) {
     (next.type === 'PunctuationNode' || next.type === 'SymbolNode') &&
     (nextValue === '"' || nextValue === "'") &&
     nextNext &&
-    (nextNext.type === 'WordNode' || nextNext.type === 'TextNode')
+    nextNext.type === 'WordNode'
   ) {
     // Special case for double sets of quotes:
     // `He said, "'Quoted' words in a larger quote."`

--- a/lib/index.js
+++ b/lib/index.js
@@ -342,11 +342,15 @@ function quotesDefault(state, node, index, parent) {
   const next = siblings[index + 1]
   const nextNext = siblings[index + 2]
   const nextValue = next ? toString(next) : ''
+  const previousValue = previous ? toString(previous) : ''
+  const closePunctuations =
+    '/／\\＼%％#＃&＆?？!！:：;；*＊-－+＋=＝~～‐‑‒–—―,、.。〃)]}»’”>＞⁆›〉》」』】〕〗〙〛）］｝｣'
 
   if (
     next &&
     (next.type === 'PunctuationNode' || next.type === 'SymbolNode') &&
-    (!nextNext || nextNext.type !== 'WordNode')
+    (!nextNext ||
+      (nextNext.type !== 'WordNode' && nextNext.type !== 'TextNode'))
   ) {
     // Special case if the very first character is a quote followed by
     // punctuation at a non-word-break. Close the quotes by brute force.
@@ -356,7 +360,7 @@ function quotesDefault(state, node, index, parent) {
     (next.type === 'PunctuationNode' || next.type === 'SymbolNode') &&
     (nextValue === '"' || nextValue === "'") &&
     nextNext &&
-    nextNext.type === 'WordNode'
+    (nextNext.type === 'WordNode' || nextNext.type === 'TextNode')
   ) {
     // Special case for double sets of quotes:
     // `He said, "'Quoted' words in a larger quote."`
@@ -371,10 +375,12 @@ function quotesDefault(state, node, index, parent) {
       previous.type === 'PunctuationNode' ||
       previous.type === 'SymbolNode') &&
     next &&
-    next.type === 'WordNode'
+    (next.type === 'WordNode' || next.type === 'TextNode')
   ) {
     // Get most opening single quotes.
-    node.value = state.open[quoteIndex]
+    node.value = closePunctuations.includes(previousValue)
+      ? state.close[quoteIndex]
+      : state.open[quoteIndex]
   } else if (
     previous &&
     previous.type !== 'WhiteSpaceNode' &&

--- a/test.js
+++ b/test.js
@@ -269,6 +269,36 @@ test('Curly quotes', async function (t) {
       assert.equal(processor.processSync('"~').toString(), '”~')
     }
   )
+
+  await t.test(
+    'should curl quotes followed by punctuation at the end of a word',
+    async function () {
+      assert.equal(
+        processor.processSync("'한국어(테스트)'입니다.").toString(),
+        '‘한국어(테스트)’입니다.'
+      )
+    }
+  )
+
+  await t.test(
+    'should curl quotes followed by punctuation at the end of a word #1',
+    async function () {
+      assert.equal(
+        processor.processSync("'누구인가?'라고 말했다.").toString(),
+        '‘누구인가?’라고 말했다.'
+      )
+    }
+  )
+
+  await t.test(
+    'should curl quotes followed by punctuation at the end of a word #2',
+    async function () {
+      assert.equal(
+        processor.processSync("'맛있다~'라며 감탄했다.").toString(),
+        '‘맛있다~’라며 감탄했다.'
+      )
+    }
+  )
 })
 
 test('En- and em-dashes', async function (t) {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/retextjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/retextjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/retextjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aretextjs&type=issues and https://github.com/orgs/retextjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Fixes the issue with closing quote after parentheses and brackets. This is mainly a problem in CJK languages.

* Before: `‘한국어(테스트)‘입니다.`
* After: `‘한국어(테스트)’입니다.`

If there is a better way, please update. Thanks!

<!--do not edit: pr-->
